### PR TITLE
feat: better cli command ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "base64",
  "bcrypt",
  "clap",
+ "dirs",
  "reqwest",
  "serde",
  "serde_json",
@@ -505,6 +506,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1150,6 +1172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1380,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
@@ -1579,6 +1617,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/aether-cli/Cargo.toml
+++ b/aether-cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 clap = { version = "4.5.53", features = ["derive"]}
 reqwest = { version = "0.12", features = ["json"]}
+dirs = "6.0.0"
 aether-core = { path = "../aether-core"}
 aether-worker = { path = "../aether-worker"}
 aether-broker = { path = "../aether-broker"}

--- a/aether-cli/src/commands.rs
+++ b/aether-cli/src/commands.rs
@@ -83,16 +83,18 @@ pub enum WorkerCommands {
     },
 }
 
+// TODO: Right now, if none of all 3 of broker_ip, broker_api_port and token are provided,
+// defaults to use the config in ~/.aether/config.json, which is the intended way.
+// There's a fundamental problem with circular command dependencies that if either only
+// token or both broker_api_port and token are given, it will still let the command work,
+// but will use the config.json behind the scenes anyway.
 #[derive(Subcommand)]
 pub enum TaskCommands {
     Submit {
-        #[arg(long, conflicts_with_all = ["broker_ip", "broker_api_port", "token"])]
-        profile: Option<String>,
-
-        #[arg(long, required_unless_present = "profile")]
+        #[arg(long, requires_all = ["broker_api_port", "token"])]
         broker_ip: Option<String>,
 
-        #[arg(long, required_unless_present = "profile")]
+        #[arg(long, requires = "token")]
         broker_api_port: Option<usize>,
 
         #[arg(long)]
@@ -110,44 +112,44 @@ pub enum TaskCommands {
         #[arg(value_enum, long, default_value_t = SupportedArchs::X86_64)]
         arch: SupportedArchs,
 
-        #[arg(long, required_unless_present = "profile")]
+        #[arg(long)]
         token: Option<String>,
     },
     Stop {
-        #[arg(long)]
-        broker_ip: String,
+        #[arg(long, requires_all = ["broker_api_port", "token"])]
+        broker_ip: Option<String>,
 
-        #[arg(long)]
-        broker_api_port: usize,
+        #[arg(long, requires = "token")]
+        broker_api_port: Option<usize>,
 
         #[arg(long)]
         task_id: String,
 
         #[arg(long)]
-        token: String,
+        token: Option<String>,
     },
     Check {
-        #[arg(long)]
-        broker_ip: String,
+        #[arg(long, requires_all = ["broker_api_port", "token"])]
+        broker_ip: Option<String>,
 
-        #[arg(long)]
-        broker_api_port: usize,
+        #[arg(long, requires = "token")]
+        broker_api_port: Option<usize>,
 
         #[arg(long)]
         task_id: String,
 
         #[arg(long)]
-        token: String,
+        token: Option<String>,
     },
     List {
-        #[arg(long)]
-        broker_ip: String,
+        #[arg(long, requires_all = ["broker_api_port", "token"])]
+        broker_ip: Option<String>,
+
+        #[arg(long, requires = "token")]
+        broker_api_port: Option<usize>,
 
         #[arg(long)]
-        broker_api_port: usize,
-
-        #[arg(long)]
-        token: String,
+        token: Option<String>,
     },
 }
 

--- a/aether-cli/src/commands.rs
+++ b/aether-cli/src/commands.rs
@@ -187,6 +187,9 @@ pub enum AuthCommands {
     #[command(about = "Log in with the provided credentials and save the JWT token.")]
     Login {
         #[arg(long)]
+        profile: String,
+
+        #[arg(long)]
         broker_ip: String,
 
         #[arg(long)]

--- a/aether-cli/src/commands.rs
+++ b/aether-cli/src/commands.rs
@@ -208,5 +208,8 @@ pub enum AuthCommands {
     },
     Switch {
         profile: String,
+    },
+    Logout {
+        profile: String,
     }
 }

--- a/aether-cli/src/commands.rs
+++ b/aether-cli/src/commands.rs
@@ -86,11 +86,14 @@ pub enum WorkerCommands {
 #[derive(Subcommand)]
 pub enum TaskCommands {
     Submit {
-        #[arg(long)]
-        broker_ip: String,
+        #[arg(long, conflicts_with_all = ["broker_ip", "broker_api_port", "token"])]
+        profile: Option<String>,
 
-        #[arg(long)]
-        broker_api_port: usize,
+        #[arg(long, required_unless_present = "profile")]
+        broker_ip: Option<String>,
+
+        #[arg(long, required_unless_present = "profile")]
+        broker_api_port: Option<usize>,
 
         #[arg(long)]
         task_file: String,
@@ -107,8 +110,8 @@ pub enum TaskCommands {
         #[arg(value_enum, long, default_value_t = SupportedArchs::X86_64)]
         arch: SupportedArchs,
 
-        #[arg(long)]
-        token: String,
+        #[arg(long, required_unless_present = "profile")]
+        token: Option<String>,
     },
     Stop {
         #[arg(long)]

--- a/aether-cli/src/commands.rs
+++ b/aether-cli/src/commands.rs
@@ -206,4 +206,7 @@ pub enum AuthCommands {
         #[arg(long)]
         password: String,
     },
+    Switch {
+        profile: String,
+    }
 }

--- a/aether-cli/src/config.rs
+++ b/aether-cli/src/config.rs
@@ -8,7 +8,7 @@ pub struct AetherConfig {
     pub active: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct BrokerProfile {
     pub broker_ip: String,
     pub broker_api_port: usize,
@@ -73,6 +73,27 @@ impl BrokerProfile {
             broker_ip: broker_ip.into(),
             broker_api_port,
             token: Some(token.into()),
+        }
+    }
+
+    pub fn resolve(
+        profile: Option<String>,
+        broker_ip: Option<String>,
+        broker_api_port: Option<usize>,
+        token: Option<String>,
+    ) -> anyhow::Result<Self> {
+        if let Some(profile) = profile {
+            let cfg = AetherConfig::get()?;
+            if let Some(prf) = cfg.profiles.get(&profile).cloned() {
+                return Ok(prf);
+            }
+            anyhow::bail!("The provided profile does not exist.");
+        } else {
+            Ok(Self {
+                broker_ip: broker_ip.unwrap(),
+                broker_api_port: broker_api_port.unwrap(),
+                token: Some(token.unwrap()),
+            })
         }
     }
 }

--- a/aether-cli/src/config.rs
+++ b/aether-cli/src/config.rs
@@ -48,7 +48,7 @@ impl AetherConfig {
         }
     }
 
-    fn save(&self) -> anyhow::Result<()> {
+    pub fn save(&self) -> anyhow::Result<()> {
         let path = Self::aether_path()?;
 
         if let Some(parent) = path.parent() {

--- a/aether-cli/src/config.rs
+++ b/aether-cli/src/config.rs
@@ -1,0 +1,113 @@
+use std::{collections::HashMap, fs::OpenOptions, io::Write, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct AetherConfig {
+    pub profiles: HashMap<String, BrokerProfile>,
+    pub active: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct BrokerProfile {
+    pub broker_ip: String,
+    pub broker_api_port: usize,
+    pub token: Option<String>,
+}
+
+impl AetherConfig {
+    const AETHER_REL_PATH: &str = ".aether/config.json";
+
+    pub fn aether_path() -> anyhow::Result<PathBuf> {
+        let home = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+
+        Ok(home.join(Self::AETHER_REL_PATH))
+    }
+
+    pub fn get() -> anyhow::Result<Self> {
+        let path = Self::aether_path()?;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        if path.exists() {
+            let file = std::fs::File::open(&path)?;
+            Ok(serde_json::from_reader(file)?)
+        } else {
+            let default_cfg = AetherConfig {
+                profiles: HashMap::new(),
+                active: None,
+            };
+
+            let mut file = std::fs::File::create(&path)?;
+            file.write_all(serde_json::to_string_pretty(&default_cfg)?.as_bytes())?;
+
+            Ok(default_cfg)
+        }
+    }
+
+    fn save(&self) -> anyhow::Result<()> {
+        let path = Self::aether_path()?;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(&path)?;
+
+        file.write_all(serde_json::to_string_pretty(self)?.as_bytes())?;
+
+        Ok(())
+    }
+}
+
+impl BrokerProfile {
+    pub fn new(broker_ip: &str, broker_api_port: usize, token: &str) -> Self {
+        Self {
+            broker_ip: broker_ip.into(),
+            broker_api_port,
+            token: Some(token.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_file_creation() {
+        let path = AetherConfig::aether_path().unwrap();
+        let cfg = AetherConfig::get().unwrap();
+        assert!(path.exists());
+        assert_eq!(
+            cfg,
+            AetherConfig {
+                profiles: HashMap::new(),
+                active: None
+            }
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn test_config_file_save() {
+        let path = AetherConfig::aether_path().unwrap();
+        let profile = BrokerProfile::new("127.0.0.1", 8080, "fake-jwt");
+        let mut cfg = AetherConfig {
+            profiles: HashMap::new(),
+            active: None,
+        };
+        cfg.profiles.insert("sample_server".into(), profile);
+        _ = std::fs::remove_file(path);
+        cfg.save().unwrap();
+        let fs_cfg = AetherConfig::get().unwrap();
+        assert_eq!(cfg, fs_cfg)
+    }
+}

--- a/aether-cli/src/config.rs
+++ b/aether-cli/src/config.rs
@@ -77,23 +77,29 @@ impl BrokerProfile {
     }
 
     pub fn resolve(
-        profile: Option<String>,
         broker_ip: Option<String>,
         broker_api_port: Option<usize>,
         token: Option<String>,
     ) -> anyhow::Result<Self> {
-        if let Some(profile) = profile {
-            let cfg = AetherConfig::get()?;
-            if let Some(prf) = cfg.profiles.get(&profile).cloned() {
-                return Ok(prf);
-            }
-            anyhow::bail!("The provided profile does not exist.");
-        } else {
+        if let Some(broker_ip) = broker_ip
+            && let Some(broker_api_port) = broker_api_port
+            && let Some(token) = token
+        {
             Ok(Self {
-                broker_ip: broker_ip.unwrap(),
-                broker_api_port: broker_api_port.unwrap(),
-                token: Some(token.unwrap()),
+                broker_ip,
+                broker_api_port,
+                token: Some(token),
             })
+        } else {
+            let cfg = AetherConfig::get()?;
+            if let Some(active) = cfg.active {
+                if let Some(prf) = cfg.profiles.get(&active).cloned() {
+                    return Ok(prf);
+                }
+                anyhow::bail!("Could not get active profile for unexpected reasons");
+            } else {
+                anyhow::bail!("There's no active default profile.");
+            }
         }
     }
 }

--- a/aether-cli/src/main.rs
+++ b/aether-cli/src/main.rs
@@ -279,6 +279,16 @@ async fn main() {
                 },
                 Err(err) => eprintln!("ERROR: {err}"),
             },
+            AuthCommands::Switch { profile } => {
+                let mut cfg = AetherConfig::get().expect("To be able to get the config file.");
+                if cfg.profiles.contains_key(&profile) {
+                    cfg.active = Some(profile.clone());
+                    cfg.save().expect("Could not save the profile switch.");
+                    println!("Auth profile switched to {profile}.");
+                } else {
+                    eprintln!("Profile with name `{profile}` does not exist.");
+                }
+            }
         },
         Commands::Tui {
             broker_ip: _,

--- a/aether-cli/src/main.rs
+++ b/aether-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod auth;
 mod commands;
 mod task;
+mod config;
 
 use aether_broker::DefaultBroker;
 use aether_core::auth::{Permission, User};

--- a/aether-cli/src/main.rs
+++ b/aether-cli/src/main.rs
@@ -111,7 +111,6 @@ async fn main() {
         },
         Commands::Task { command } => match command {
             TaskCommands::Submit {
-                profile,
                 broker_ip,
                 broker_api_port,
                 task_file,
@@ -128,14 +127,13 @@ async fn main() {
                         return;
                     }
                 };
-                let tmp_profile =
-                    match BrokerProfile::resolve(profile, broker_ip, broker_api_port, token) {
-                        Ok(bp) => bp,
-                        Err(err) => {
-                            eprintln!("ERROR: {err}");
-                            return;
-                        }
-                    };
+                let tmp_profile = match BrokerProfile::resolve(broker_ip, broker_api_port, token) {
+                    Ok(bp) => bp,
+                    Err(err) => {
+                        eprintln!("ERROR: {err}");
+                        return;
+                    }
+                };
                 match send_task_to_broker(
                     &tmp_profile.broker_ip,
                     tmp_profile.broker_api_port,
@@ -168,41 +166,94 @@ async fn main() {
                 broker_api_port,
                 task_id,
                 token,
-            } => match cancel_task(&broker_ip, broker_api_port, &task_id, &token).await {
-                Ok(resp) => {
-                    println!("{}", resp.message);
+            } => {
+                let tmp_profile = match BrokerProfile::resolve(broker_ip, broker_api_port, token) {
+                    Ok(bp) => bp,
+                    Err(err) => {
+                        eprintln!("ERROR: {err}");
+                        return;
+                    }
+                };
+                match cancel_task(
+                    &tmp_profile.broker_ip,
+                    tmp_profile.broker_api_port,
+                    &task_id,
+                    &tmp_profile
+                        .token
+                        .expect("A token should have been provided on flag or config profile"),
+                )
+                .await
+                {
+                    Ok(resp) => {
+                        println!("{}", resp.message);
+                    }
+                    Err(err) => eprintln!("ERROR: {err}"),
                 }
-                Err(err) => eprintln!("ERROR: {err}"),
-            },
+            }
             TaskCommands::Check {
                 broker_ip,
                 broker_api_port,
                 task_id,
                 token,
-            } => match check_task(&broker_ip, broker_api_port, &task_id, token).await {
-                Ok(resp) => {
-                    if let Some(err) = resp.error {
-                        eprintln!("{err}");
-                    } else if let Some(task) = resp.task {
-                        let de_task = serde_json::to_string_pretty(&task)
-                            .expect("Failed deserialization of task.");
-                        println!("{de_task}");
+            } => {
+                let tmp_profile = match BrokerProfile::resolve(broker_ip, broker_api_port, token) {
+                    Ok(bp) => bp,
+                    Err(err) => {
+                        eprintln!("ERROR: {err}");
+                        return;
                     }
+                };
+                match check_task(
+                    &tmp_profile.broker_ip,
+                    tmp_profile.broker_api_port,
+                    &task_id,
+                    &tmp_profile
+                        .token
+                        .expect("A token should have been provided on flag or config profile."),
+                )
+                .await
+                {
+                    Ok(resp) => {
+                        if let Some(err) = resp.error {
+                            eprintln!("{err}");
+                        } else if let Some(task) = resp.task {
+                            let de_task = serde_json::to_string_pretty(&task)
+                                .expect("Failed deserialization of task.");
+                            println!("{de_task}");
+                        }
+                    }
+                    Err(err) => eprintln!("ERROR: {err}"),
                 }
-                Err(err) => eprintln!("ERROR: {err}"),
-            },
+            }
             TaskCommands::List {
                 broker_ip,
                 broker_api_port,
                 token,
-            } => match list_tasks(&broker_ip, broker_api_port, &token).await {
-                Ok(resp) => {
-                    let de_tasks = serde_json::to_string_pretty(&resp)
-                        .expect("Failed deserialization of all tasks");
-                    println!("{de_tasks}");
+            } => {
+                let tmp_profile = match BrokerProfile::resolve(broker_ip, broker_api_port, token) {
+                    Ok(bp) => bp,
+                    Err(err) => {
+                        eprintln!("ERROR: {err}");
+                        return;
+                    }
+                };
+                match list_tasks(
+                    &tmp_profile.broker_ip,
+                    tmp_profile.broker_api_port,
+                    &tmp_profile
+                        .token
+                        .expect("A token should have been provided on flag or config profile"),
+                )
+                .await
+                {
+                    Ok(resp) => {
+                        let de_tasks = serde_json::to_string_pretty(&resp)
+                            .expect("Failed deserialization of all tasks");
+                        println!("{de_tasks}");
+                    }
+                    Err(err) => eprintln!("ERROR: {err}"),
                 }
-                Err(err) => eprintln!("ERROR: {err}"),
-            },
+            }
         },
         Commands::Auth { command } => match command {
             AuthCommands::Login {

--- a/aether-cli/src/main.rs
+++ b/aether-cli/src/main.rs
@@ -1,7 +1,7 @@
 mod auth;
 mod commands;
-mod task;
 mod config;
+mod task;
 
 use aether_broker::DefaultBroker;
 use aether_core::auth::{Permission, User};
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 use crate::auth::get_login_jwt;
 use crate::commands::{AuthCommands, BrokerCommands, Cli, Commands, TaskCommands, WorkerCommands};
+use crate::config::{AetherConfig, BrokerProfile};
 use crate::task::{cancel_task, check_task, list_tasks, parse_task_file, send_task_to_broker};
 
 #[tokio::main]
@@ -194,13 +195,24 @@ async fn main() {
         },
         Commands::Auth { command } => match command {
             AuthCommands::Login {
+                profile,
                 broker_ip,
                 broker_api_port,
                 username,
                 password,
             } => match get_login_jwt(&broker_ip, broker_api_port, &username, &password).await {
                 Ok(resp) => match resp {
-                    LoginResponse::Ok { jwt } => println!("{jwt}"),
+                    LoginResponse::Ok { jwt } => {
+                        let mut cfg = AetherConfig::get()
+                            .expect("Could not open/generate ~/.aether/config.json.");
+                        let bp = BrokerProfile::new(&broker_ip, broker_api_port, &jwt);
+                        cfg.profiles.insert(profile.clone(), bp);
+                        cfg.active = Some(profile);
+                        cfg.save().expect(
+                            "Could not save profile configuration to ~/.aether/config.json",
+                        );
+                        println!("{jwt}");
+                    }
                     LoginResponse::Err { message } => eprintln!("ERROR: {message}"),
                 },
                 Err(err) => eprintln!("ERROR: {err}"),

--- a/aether-cli/src/main.rs
+++ b/aether-cli/src/main.rs
@@ -289,6 +289,20 @@ async fn main() {
                     eprintln!("Profile with name `{profile}` does not exist.");
                 }
             }
+            AuthCommands::Logout { profile } => {
+                let mut cfg = AetherConfig::get().expect("To be able to get the config file.");
+                if cfg.profiles.remove(&profile).is_some() {
+                    if let Some(ref act) = cfg.active
+                        && *act == profile
+                    {
+                        cfg.active = None;
+                    }
+                    cfg.save().expect("Could not save the profile switch.");
+                    println!("Profile {profile} removed.");
+                } else {
+                    eprintln!("Profile with name `{profile}` does not exist.");
+                }
+            }
         },
         Commands::Tui {
             broker_ip: _,

--- a/aether-cli/src/main.rs
+++ b/aether-cli/src/main.rs
@@ -111,6 +111,7 @@ async fn main() {
         },
         Commands::Task { command } => match command {
             TaskCommands::Submit {
+                profile,
                 broker_ip,
                 broker_api_port,
                 task_file,
@@ -127,15 +128,25 @@ async fn main() {
                         return;
                     }
                 };
+                let tmp_profile =
+                    match BrokerProfile::resolve(profile, broker_ip, broker_api_port, token) {
+                        Ok(bp) => bp,
+                        Err(err) => {
+                            eprintln!("ERROR: {err}");
+                            return;
+                        }
+                    };
                 match send_task_to_broker(
-                    &broker_ip,
-                    broker_api_port,
+                    &tmp_profile.broker_ip,
+                    tmp_profile.broker_api_port,
                     &task_b64,
                     &name,
                     priority,
                     gpu,
                     arch,
-                    &token,
+                    &tmp_profile
+                        .token
+                        .expect("A token should have been provided on flag or config file"),
                 )
                 .await
                 {

--- a/aether-cli/src/task.rs
+++ b/aether-cli/src/task.rs
@@ -73,7 +73,7 @@ pub async fn check_task(
     broker_ip: &str,
     broker_api_port: usize,
     task_id: &str,
-    token: String,
+    token: &str,
 ) -> anyhow::Result<GetTaskResponse> {
     let client = reqwest::Client::new();
     let broker_addr = format!("http://{broker_ip}:{broker_api_port}/api/v1/tasks/{task_id}");


### PR DESCRIPTION
This PR implements a mechanism to allow inline configuration of the commands via flags like `--broker-ip` and `--broker-api-port`, but also allows the user to "login" with multiple profiles and switch between them. Once a user is logged in, all the successive commands that would require the inline flags don't require anymore and default to the connection values of that profile.

This PR closes the following issues:
- Closes #26 
- Closes #32 